### PR TITLE
feat: implement write forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Then this update will be visible to all nodes:
 "123"
 ```
 
+## Features
+
+- [x] Automatic failover
+- [x] Read/Write splitting
+- [x] Write forwarding
+- [ ] Log compaction(snapshot)
+- [ ] Dynamic membership
+
 ## License
 
 Radis is licensed under the [MIT license](LICENSE).

--- a/proto/raft/raft.proto
+++ b/proto/raft/raft.proto
@@ -6,6 +6,8 @@ service Raft {
   rpc RequestVote(RequestVoteArgs) returns (RequestVoteReply) {}
   rpc AppendEntries(AppendEntriesArgs) returns (AppendEntriesReply) {}
   rpc InstallSnapshot(InstallSnapshotArgs) returns (InstallSnapshotReply) {}
+  rpc NodeInfo(NodeInfoArgs) returns (NodeInfoReply) {}
+  rpc AppendCommand(AppendCommandArgs) returns (AppendCommandReply) {}
 }
 
 message Log {
@@ -51,3 +53,11 @@ message InstallSnapshotArgs {
 }
 
 message InstallSnapshotReply { uint64 term = 1; }
+
+message NodeInfoArgs {}
+
+message NodeInfoReply {
+  string id = 1;
+  uint64 term = 2;
+  string role = 3;
+}

--- a/proto/raft/raft.proto
+++ b/proto/raft/raft.proto
@@ -7,7 +7,8 @@ service Raft {
   rpc AppendEntries(AppendEntriesArgs) returns (AppendEntriesReply) {}
   rpc InstallSnapshot(InstallSnapshotArgs) returns (InstallSnapshotReply) {}
   rpc NodeInfo(NodeInfoArgs) returns (NodeInfoReply) {}
-  }
+  rpc AppendCommand(AppendCommandArgs) returns (AppendCommandReply) {}
+}
 
 message Log {
   uint64 term = 1;
@@ -59,4 +60,11 @@ message NodeInfoReply {
   string id = 1;
   uint64 term = 2;
   string role = 3;
+}
+
+message AppendCommandArgs { bytes command = 1; }
+
+message AppendCommandReply {
+  bool success = 1;
+  string error = 2;
 }

--- a/proto/raft/raft.proto
+++ b/proto/raft/raft.proto
@@ -7,8 +7,7 @@ service Raft {
   rpc AppendEntries(AppendEntriesArgs) returns (AppendEntriesReply) {}
   rpc InstallSnapshot(InstallSnapshotArgs) returns (InstallSnapshotReply) {}
   rpc NodeInfo(NodeInfoArgs) returns (NodeInfoReply) {}
-  rpc AppendCommand(AppendCommandArgs) returns (AppendCommandReply) {}
-}
+  }
 
 message Log {
   uint64 term = 1;

--- a/src/raft/context.rs
+++ b/src/raft/context.rs
@@ -3,7 +3,7 @@ use super::log::LogManager;
 use super::service::PeerClient;
 use crate::conf::Config;
 use crate::timer::{OneshotTimer, PeriodicTimer};
-use log::{debug, info};
+use log::debug;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{self, Sender};

--- a/src/raft/context.rs
+++ b/src/raft/context.rs
@@ -4,6 +4,7 @@ use super::service::PeerClient;
 use crate::conf::Config;
 use crate::timer::{OneshotTimer, PeriodicTimer};
 use log::debug;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{self, Sender};
@@ -16,6 +17,7 @@ pub type LogIndex = u64;
 pub struct Context {
     id: String,
     peers: Vec<Arc<Mutex<PeerClient>>>,
+    id_map: Arc<HashMap<String, Peer>>,
 
     log: LogManager,
     peer_next_index: Vec<Arc<Mutex<LogIndex>>>,
@@ -40,27 +42,29 @@ impl Context {
             raft_rpc_addr: _,
             raft_peers: peer_addrs,
         } = cfg;
-        let peers = peer_addrs.len();
+        let n_peer = peer_addrs.len();
+
+        let mut id_map = HashMap::with_capacity(n_peer);
+        let mut peers = Vec::with_capacity(n_peer);
+        for (i, (id, addr)) in peer_addrs.into_iter().enumerate() {
+            debug!(target: "raft::context",
+                peer_index = i,
+                peer_id = id,
+                peer_addr = addr,
+                timeout:serde = timeout;
+                "init peer client"
+            );
+            id_map.insert(id, i);
+            peers.push(Arc::new(Mutex::new(PeerClient::new(&addr, timeout))));
+        }
 
         Self {
             id,
-            peers: peer_addrs
-                .iter()
-                .enumerate()
-                .map(|(i, addr)| {
-                    debug!(target: "raft::context",
-                        peer_index = i,
-                        peer_addr = addr,
-                        timeout:serde = timeout;
-                        "init peer client"
-                    );
-                    Arc::new(Mutex::new(PeerClient::new(addr, timeout)))
-                })
-                .collect(),
-
+            peers,
+            id_map: Arc::new(id_map),
             log: LogManager::new(),
-            peer_next_index: (0..peers).map(|_| Arc::new(Mutex::new(0))).collect(),
-            peer_sync_index: (0..peers).map(|_| Arc::new(RwLock::new(0))).collect(),
+            peer_next_index: (0..n_peer).map(|_| Arc::new(Mutex::new(0))).collect(),
+            peer_sync_index: (0..n_peer).map(|_| Arc::new(RwLock::new(0))).collect(),
             commit_ch,
 
             timeout: Arc::new(OneshotTimer::new(timeout_event)),
@@ -87,6 +91,10 @@ impl Context {
 
     pub fn get_peer(&self, peer: Peer) -> Arc<Mutex<PeerClient>> {
         self.peers[peer].clone()
+    }
+
+    pub fn get_peer_by_id(&self, id: &str) -> Option<Arc<Mutex<PeerClient>>> {
+        self.id_map.get(id).map(|&peer| self.peers[peer].clone())
     }
 
     pub fn peers(&self) -> usize {

--- a/src/raft/service.rs
+++ b/src/raft/service.rs
@@ -1,8 +1,9 @@
 use super::context::Context;
 use super::state::{self, State};
 use super::{
-    AppendEntriesArgs, AppendEntriesReply, InstallSnapshotArgs, InstallSnapshotReply, NodeInfoArgs,
-    NodeInfoReply, RaftServer, RequestVoteArgs, RequestVoteReply,
+    AppendCommandArgs, AppendCommandReply, AppendEntriesArgs, AppendEntriesReply,
+    InstallSnapshotArgs, InstallSnapshotReply, NodeInfoArgs, NodeInfoReply, RaftServer,
+    RequestVoteArgs, RequestVoteReply,
 };
 use super::{Raft, RaftClient};
 use crate::conf::Config;
@@ -52,12 +53,39 @@ impl RaftService {
     pub async fn append_command(&self, cmd: Vec<u8>) -> Result<()> {
         info!(target: "raft::service", id = self.id; "append command");
         let state = self.state.lock().await;
-        let new_state = state.on_command(self.context.clone(), cmd).await?;
-        if state::transition(state, new_state, self.context.clone()).await {
-            Err(anyhow::anyhow!("not leader"))
-        } else {
-            Ok(())
+        match state.role() {
+            state::Role::Follower => {
+                if let Some(leader_id) = state.following() {
+                    let leader = self
+                        .context
+                        .read()
+                        .await
+                        .get_peer_by_id(&leader_id)
+                        .ok_or(anyhow::anyhow!("unknown leader id"))?;
+                    drop(state);
+                    let resp = leader
+                        .lock()
+                        .await
+                        .append_command(AppendCommandArgs { command: cmd })
+                        .await?;
+                    if resp.success {
+                        return Ok(());
+                    } else {
+                        return Err(anyhow::anyhow!(resp.error));
+                    }
+                }
+            }
+            state::Role::Candidate => {}
+            state::Role::Leader => {
+                let new_state = state.on_command(self.context.clone(), cmd).await?;
+                if state::transition(state, new_state, self.context.clone()).await {
+                    return Err(anyhow::anyhow!("not leader"));
+                } else {
+                    return Ok(());
+                }
+            }
         }
+        return Err(anyhow::anyhow!("still in election"));
     }
 
     pub async fn serve(&self) -> Result<()> {
@@ -159,6 +187,26 @@ impl Raft for RaftService {
             role: state.role().to_string(),
         }))
     }
+
+    async fn append_command(
+        &self,
+        request: Request<AppendCommandArgs>,
+    ) -> Result<Response<AppendCommandReply>, Status> {
+        let request = request.into_inner();
+        trace!(
+            target: "raft::rpc",
+            "received AppendCommand request",
+        );
+        self.append_command(request.command)
+            .await
+            .map(|_| {
+                Ok(Response::new(AppendCommandReply {
+                    success: true,
+                    error: "".to_string(),
+                }))
+            })
+            .map_err(|e| Status::aborted(e.to_string()))?
+    }
 }
 
 pub struct PeerClient {
@@ -236,5 +284,22 @@ impl PeerClient {
     pub async fn node_info(&mut self, args: NodeInfoArgs) -> Result<NodeInfoReply, Status> {
         let resp = self.connect().await?.node_info(Request::new(args)).await?;
         Ok(resp.into_inner())
+    }
+
+    pub async fn append_command(
+        &mut self,
+        args: AppendCommandArgs,
+    ) -> Result<AppendCommandReply, Status> {
+        let resp = self
+            .connect()
+            .await?
+            .append_command(Request::new(args))
+            .await?
+            .into_inner();
+        if resp.success {
+            Ok(resp)
+        } else {
+            Err(Status::failed_precondition(resp.error))
+        }
     }
 }

--- a/src/raft/state.rs
+++ b/src/raft/state.rs
@@ -28,6 +28,16 @@ pub enum Role {
     Leader,
 }
 
+impl Role {
+    pub fn to_string(&self) -> String {
+        match self {
+            Role::Follower => "Follower".to_string(),
+            Role::Candidate => "Candidate".to_string(),
+            Role::Leader => "Leader".to_string(),
+        }
+    }
+}
+
 #[tonic::async_trait]
 pub trait State: Sync + Send + Debug {
     fn term(&self) -> Term;

--- a/src/raft/state/candidate.rs
+++ b/src/raft/state/candidate.rs
@@ -57,7 +57,7 @@ impl State for CandidateState {
         _ctx: RaftContext,
         _cmd: Vec<u8>,
     ) -> anyhow::Result<Option<Arc<Box<dyn State>>>> {
-        Err(anyhow::anyhow!("not leader"))
+        unimplemented!()
     }
 
     async fn request_vote_logic(

--- a/src/raft/state/follower.rs
+++ b/src/raft/state/follower.rs
@@ -151,7 +151,7 @@ impl State for FollowerState {
         _ctx: RaftContext,
         _cmd: Vec<u8>,
     ) -> anyhow::Result<Option<Arc<Box<dyn State>>>> {
-        Err(anyhow::anyhow!("not leader"))
+        unimplemented!();
     }
 
     async fn request_vote_logic(


### PR DESCRIPTION
## Features

- Implement new rpc `NodeInfo` for getting peer metadata.
- Add peer's id to configuration schema so that node can get peer's rpc client by id.
- Implement new rpc `AppendCommand` for forwarding write requests.

## Test

- New test case for write forwarding.

## Doc

- Add `Features` section to README.