### PR TITLE
feat: persistence with WAL

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,5 +21,5 @@ jobs:
     - name: Build
       run: sudo apt-get install protobuf-compiler -y && cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --workspace
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,19 @@
 
 [workspace]
     members = [
+        "crates/persister",
         "crates/raft",
         "crates/timer",
     ]
     [workspace.dependencies]
         timer = {path = "crates/timer"}
         raft = {path = "crates/raft"}
+        persister = {path = "crates/persister"}
 
 [dependencies]
     timer.workspace = true
     raft.workspace = true
+    persister.workspace = true
     anyhow = "1.0.86"
     bytes = {version = "1.6.1", features = [
         "serde",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Then this update will be visible to all nodes:
 - [x] Automatic failover
 - [x] Read/Write splitting
 - [x] Write forwarding
+- [x] Persistence(WAL)
 - [ ] Log compaction(snapshot)
 - [ ] Dynamic membership
 

--- a/crates/persister/Cargo.toml
+++ b/crates/persister/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+    name = "persister"
+    version = "0.1.0"
+    edition = "2021"
+
+[dependencies]
+    raft.workspace = true
+    anyhow = "1.0.86"
+    tokio = {version = "1.39.3", features = [
+        "rt-multi-thread",
+        "macros",
+        "fs",
+    ]}
+    async-trait = "0.1.81"

--- a/crates/persister/src/file.rs
+++ b/crates/persister/src/file.rs
@@ -1,34 +1,95 @@
 use super::{Persister, Term};
 use anyhow::Result;
 use async_trait::async_trait;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::{AsyncReadExt, AsyncWriteExt},
+};
 
 pub struct FilePersister {
     dir: String,
+
+    wal_w: Option<File>,
+    wal_r: Option<File>,
 }
 
 impl FilePersister {
     pub fn new(dir: &str) -> Self {
         Self {
             dir: String::from(dir),
+            wal_w: None,
+            wal_r: None,
         }
+    }
+
+    async fn wal_write_handle(&mut self) -> &mut File {
+        if self.wal_w.is_none() {
+            std::fs::create_dir_all(format!("{}/wal", self.dir)).unwrap();
+            let path = format!("{}/wal/log", self.dir);
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(path)
+                .await
+                .unwrap();
+            self.wal_w = Some(file);
+        }
+        self.wal_w.as_mut().unwrap()
+    }
+
+    async fn wal_read_handle(&mut self) -> &mut File {
+        if self.wal_r.is_none() {
+            let path = format!("{}/wal/log", self.dir);
+            let file = File::open(path).await.unwrap();
+            self.wal_r = Some(file);
+        }
+        self.wal_r.as_mut().unwrap()
     }
 }
 
 #[async_trait]
 impl Persister for FilePersister {
     async fn read_wal(&mut self) -> Result<Option<(Term, Vec<u8>)>> {
-        todo!()
+        let wal = self.wal_read_handle().await;
+
+        // Read the length of the entry
+        let mut length_bytes = [0u8; size_of::<usize>()];
+        match wal.read_exact(&mut length_bytes).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                // Close current wal file so next call can read it again
+                self.wal_r = None;
+                return Ok(None);
+            }
+            Err(e) => return Err(e.into()),
+        }
+        let length = usize::from_le_bytes(length_bytes);
+
+        // Read the term
+        let mut term_bytes = [0u8; size_of::<Term>()];
+        wal.read_exact(&mut term_bytes).await?;
+        let term = Term::from_le_bytes(term_bytes);
+
+        // Read the data
+        let mut data = vec![0u8; length - size_of::<Term>()];
+        wal.read_exact(&mut data).await?;
+
+        Ok(Some((term, data)))
     }
 
     async fn write_wal(&mut self, term: Term, data: &[u8]) -> Result<()> {
-        todo!()
+        let wal = self.wal_write_handle().await;
+        let length = size_of::<Term>() + data.len();
+        wal.write(&length.to_le_bytes()).await?;
+        wal.write(&term.to_le_bytes()).await?;
+        wal.write(data).await?;
+        Ok(())
     }
 
     async fn read_snapshot(&self) -> Result<Option<(usize, Vec<u8>)>> {
         todo!()
     }
-
-    async fn write_snapshot(&mut self, last_index: usize, data: &[u8]) -> Result<()> {
+    async fn write_snapshot(&mut self, _last_index: usize, _data: &[u8]) -> Result<()> {
         todo!()
     }
 }

--- a/crates/persister/src/file.rs
+++ b/crates/persister/src/file.rs
@@ -1,0 +1,34 @@
+use super::{Persister, Term};
+use anyhow::Result;
+use async_trait::async_trait;
+
+pub struct FilePersister {
+    dir: String,
+}
+
+impl FilePersister {
+    pub fn new(dir: &str) -> Self {
+        Self {
+            dir: String::from(dir),
+        }
+    }
+}
+
+#[async_trait]
+impl Persister for FilePersister {
+    async fn read_wal(&mut self) -> Result<Option<(Term, Vec<u8>)>> {
+        todo!()
+    }
+
+    async fn write_wal(&mut self, term: Term, data: &[u8]) -> Result<()> {
+        todo!()
+    }
+
+    async fn read_snapshot(&self) -> Result<Option<(usize, Vec<u8>)>> {
+        todo!()
+    }
+
+    async fn write_snapshot(&mut self, last_index: usize, data: &[u8]) -> Result<()> {
+        todo!()
+    }
+}

--- a/crates/persister/src/lib.rs
+++ b/crates/persister/src/lib.rs
@@ -1,0 +1,6 @@
+pub use raft::state::Term;
+pub use raft::Persister;
+
+mod file;
+
+pub use file::FilePersister;

--- a/crates/persister/tests/file_test.rs
+++ b/crates/persister/tests/file_test.rs
@@ -1,0 +1,39 @@
+use persister::FilePersister;
+use persister::Persister;
+
+#[tokio::test]
+async fn rw_wal() {
+    let mut fp = fp_at("file");
+
+    let write_wal = vec![
+        (1, "wal_test".as_bytes()),
+        (2, "wal_test2".as_bytes()),
+        (3, "wal_test3".as_bytes()),
+    ];
+    for (term, data) in write_wal.iter() {
+        fp.write_wal(*term, *data).await.unwrap();
+    }
+
+    for (term, data) in write_wal.iter() {
+        let (t, d) = fp.read_wal().await.unwrap().unwrap();
+        assert_eq!(t, *term);
+        assert_eq!(d.as_slice(), *data);
+    }
+
+    assert_eq!(None, fp.read_wal().await.unwrap());
+
+    // When meet EOF, next `read_wal` should start from the beginning
+    for (term, data) in write_wal.iter() {
+        let (t, d) = fp.read_wal().await.unwrap().unwrap();
+        assert_eq!(t, *term);
+        assert_eq!(d.as_slice(), *data);
+    }
+
+    assert_eq!(None, fp.read_wal().await.unwrap());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+fn fp_at(dir: &str) -> FilePersister {
+    FilePersister::new(format!("/tmp/radis/test/persister/{}", dir).as_str())
+}

--- a/crates/persister/tests/file_test.rs
+++ b/crates/persister/tests/file_test.rs
@@ -2,6 +2,12 @@ use persister::FilePersister;
 use persister::Persister;
 
 #[tokio::test]
+async fn wal_not_exist() {
+    let mut fp = fp_at("not_exist");
+    assert_eq!(None, fp.read_wal().await.unwrap());
+}
+
+#[tokio::test]
 async fn rw_wal() {
     let mut fp = fp_at("file");
 

--- a/crates/raft/Cargo.toml
+++ b/crates/raft/Cargo.toml
@@ -22,6 +22,7 @@
         "rt-multi-thread",
     ]}
     tonic = "0.12.1"
+    async-trait = "0.1.81"
 
 [build-dependencies]
     tonic-build = "0.11.0"

--- a/crates/raft/src/context.rs
+++ b/crates/raft/src/context.rs
@@ -2,6 +2,8 @@ use super::config::Config;
 use super::config::REQUEST_TIMEOUT;
 use super::log::LogManager;
 use super::service::PeerClient;
+use super::Persister;
+use anyhow::Result;
 use log::debug;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -67,6 +69,10 @@ impl Context {
             timeout: Arc::new(OneshotTimer::new(timeout_event)),
             tick: Arc::new(PeriodicTimer::new(tick_event)),
         }
+    }
+
+    pub async fn setup_persister(&mut self, persister: Box<dyn Persister>) -> Result<()> {
+        self.log.setup_persister(persister).await
     }
 
     pub async fn init_timer(&self) {

--- a/crates/raft/src/lib.rs
+++ b/crates/raft/src/lib.rs
@@ -8,4 +8,5 @@ mod log;
 mod service;
 pub mod state;
 
+pub use log::Persister;
 pub use service::RaftService;

--- a/crates/raft/src/log.rs
+++ b/crates/raft/src/log.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc;
 pub trait Persister: Sync + Send {
     /// Reading WAL since the last snapshot
     /// Read a single log each time, return `Ok(None)` on EOF
-    async fn replay_wal(&mut self) -> Result<Option<(Term, Vec<u8>)>>;
+    async fn read_wal(&mut self) -> Result<Option<(Term, Vec<u8>)>>;
     async fn write_wal(&mut self, term: Term, data: &[u8]) -> Result<()>;
 
     async fn read_snapshot(&self) -> Result<Option<(usize, Vec<u8>)>>;
@@ -79,7 +79,7 @@ impl LogManager {
             self.snapshot = Some(data);
         }
 
-        while let Some((term, command)) = p.replay_wal().await? {
+        while let Some((term, command)) = p.read_wal().await? {
             self.logs.push(InnerLog::new(term, command));
         }
         info!(target: "raft::persist",

--- a/crates/raft/src/log.rs
+++ b/crates/raft/src/log.rs
@@ -2,12 +2,13 @@ use super::context::LogIndex;
 use super::state::Term;
 use super::Log;
 use anyhow::Result;
+use async_trait::async_trait;
 use log::{debug, error, info};
 use std::ops::Deref;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-#[tonic::async_trait]
+#[async_trait]
 pub trait Persister: Sync + Send {
     /// Reading WAL since the last snapshot
     /// Read a single log each time, return `Ok(None)` on EOF

--- a/crates/raft/src/service.rs
+++ b/crates/raft/src/service.rs
@@ -3,7 +3,7 @@ use super::context::Context;
 use super::state::{self, State};
 use super::{
     AppendCommandArgs, AppendCommandReply, AppendEntriesArgs, AppendEntriesReply,
-    InstallSnapshotArgs, InstallSnapshotReply, NodeInfoArgs, NodeInfoReply, RaftServer,
+    InstallSnapshotArgs, InstallSnapshotReply, NodeInfoArgs, NodeInfoReply, Persister, RaftServer,
     RequestVoteArgs, RequestVoteReply,
 };
 use super::{Raft, RaftClient};
@@ -50,6 +50,24 @@ impl RaftService {
         self.state.clone()
     }
 
+    pub async fn setup_persister(&self, persister: Box<dyn Persister>) -> Result<()> {
+        self.context.write().await.setup_persister(persister).await
+    }
+
+    pub async fn serve(&self) -> Result<()> {
+        let (close_tx, mut close_rx) = mpsc::channel::<()>(1);
+        *self.close_ch.lock().await = Some(close_tx);
+        let addr = self.listen_addr.parse()?;
+        info!(target: "raft::service", id = self.id; "raft gRPC server listening on {addr}");
+        Server::builder()
+            .add_service(RaftServer::new(self.clone()))
+            .serve_with_shutdown(addr, async move {
+                close_rx.recv().await;
+            })
+            .await?;
+        Ok(())
+    }
+
     pub async fn append_command(&self, cmd: Vec<u8>) -> Result<()> {
         info!(target: "raft::service", id = self.id; "append command");
         let state = self.state.lock().await;
@@ -86,20 +104,6 @@ impl RaftService {
             }
         }
         return Err(anyhow::anyhow!("still in election"));
-    }
-
-    pub async fn serve(&self) -> Result<()> {
-        let (close_tx, mut close_rx) = mpsc::channel::<()>(1);
-        *self.close_ch.lock().await = Some(close_tx);
-        let addr = self.listen_addr.parse()?;
-        info!(target: "raft::service", id = self.id; "raft gRPC server listening on {addr}");
-        Server::builder()
-            .add_service(RaftServer::new(self.clone()))
-            .serve_with_shutdown(addr, async move {
-                close_rx.recv().await;
-            })
-            .await?;
-        Ok(())
     }
 
     pub async fn close(&self) {

--- a/crates/raft/src/service.rs
+++ b/crates/raft/src/service.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use super::{Raft, RaftClient};
 use anyhow::Result;
+use async_trait::async_trait;
 use log::{info, trace};
 use std::sync::Arc;
 use std::time::Duration;
@@ -118,7 +119,7 @@ impl RaftService {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Raft for RaftService {
     async fn request_vote(
         &self,

--- a/crates/raft/src/service.rs
+++ b/crates/raft/src/service.rs
@@ -50,6 +50,8 @@ impl RaftService {
         self.state.clone()
     }
 
+    /// Setup persister for wal and snapshot.
+    /// This method must be called before `RaftService::serve()`
     pub async fn setup_persister(&self, persister: Box<dyn Persister>) -> Result<()> {
         self.context.write().await.setup_persister(persister).await
     }

--- a/crates/raft/src/state.rs
+++ b/crates/raft/src/state.rs
@@ -5,6 +5,7 @@ use super::{
     AppendEntriesArgs, AppendEntriesReply, InstallSnapshotArgs, InstallSnapshotReply,
     RequestVoteArgs, RequestVoteReply,
 };
+use async_trait::async_trait;
 use log::{debug, error, info};
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
@@ -38,7 +39,7 @@ impl Role {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 pub trait State: Sync + Send + Debug {
     fn term(&self) -> Term;
     fn role(&self) -> Role;

--- a/crates/raft/src/state/candidate.rs
+++ b/crates/raft/src/state/candidate.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use super::{PeerID, RaftContext, Role, State, Term};
 use crate::config;
+use async_trait::async_trait;
 use futures::future;
 use log::{debug, error, info};
 use serde::Serialize;
@@ -24,7 +25,7 @@ impl CandidateState {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl State for CandidateState {
     fn term(&self) -> Term {
         self.term

--- a/crates/raft/src/state/follower.rs
+++ b/crates/raft/src/state/follower.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use super::{LogIndex, PeerID, RaftContext, Role, State, Term};
 use crate::config;
+use async_trait::async_trait;
 use log::{debug, info};
 use serde::Serialize;
 use std::sync::Arc;
@@ -119,7 +120,7 @@ impl FollowerState {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl State for FollowerState {
     fn term(&self) -> Term {
         self.term

--- a/crates/raft/src/state/leader.rs
+++ b/crates/raft/src/state/leader.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use super::{PeerID, RaftContext, Role, State, Term};
 use crate::config;
+use async_trait::async_trait;
 use futures::future;
 use log::{debug, error, info};
 use serde::Serialize;
@@ -141,7 +142,7 @@ impl LeaderState {
     }
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl State for LeaderState {
     fn term(&self) -> Term {
         self.term

--- a/crates/raft/tests/raft_test.rs
+++ b/crates/raft/tests/raft_test.rs
@@ -122,6 +122,8 @@ async fn persistent() {
     // Expect all committed commands to be commit again
     let leader = ctl.leader().await;
     ctl.agree_one(leader, data).await;
+
+    ctl.close_all().await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/crates/raft/tests/raft_test.rs
+++ b/crates/raft/tests/raft_test.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use raft::config::Config;
 use raft::state;
 use raft::RaftService;
@@ -12,7 +13,7 @@ async fn leader_election() {
     ctl.serve_all().await;
 
     // Wait for establishing agreement on one leader
-    sleep(Duration::from_millis(1000)).await;
+    ctl.leader().await;
 
     let (followers, candidates, leader_cnt) = ctl.count_roles().await;
     // There should be only one leader, and all others are followers
@@ -21,8 +22,6 @@ async fn leader_election() {
     assert_eq!(leader_cnt, 1);
 
     ctl.close_all().await;
-    // Wait for all connections to finish
-    sleep(Duration::from_millis(500)).await;
 }
 
 #[tokio::test]
@@ -31,24 +30,19 @@ async fn fail_over() {
     ctl.serve_all().await;
 
     // Wait for establishing agreement on one leader
-    sleep(Duration::from_millis(1000)).await;
-
-    let (followers, candidates, leader_cnt) = ctl.count_roles().await;
-    // There should be only one leader, and all others are followers
-    assert_eq!(followers, 2);
-    assert_eq!(candidates, 0);
-    assert_eq!(leader_cnt, 1);
+    let old_leader = ctl.leader().await;
 
     // Leader offline
-    let old_leader = ctl.leader().await.unwrap();
     let old_term = ctl.term(old_leader).await;
     ctl.close(old_leader).await;
 
     // Wait for one follower timeout and start new election
     sleep(Duration::from_millis(1000)).await;
 
-    let (followers, candidates, leader_cnt) = ctl.count_roles().await;
     // There should be a new leader got elected
+    ctl.leader().await;
+
+    let (followers, candidates, leader_cnt) = ctl.count_roles().await;
     assert_eq!(followers, 1);
     assert_eq!(candidates, 0);
     assert_eq!(leader_cnt, 2); // New leader plus old leader
@@ -58,17 +52,14 @@ async fn fail_over() {
     ctl.setup_timer(old_leader).await;
 
     // Wait for re-establishing agreement on new leader
-    sleep(Duration::from_millis(1000)).await;
-
-    let new_leader = ctl.leader().await.unwrap();
+    sleep(Duration::from_millis(500)).await;
+    let new_leader = ctl.leader().await;
     let new_term = ctl.term(new_leader).await;
     // The old leader should be replaced by the new leader with a higher term
     assert_ne!(old_leader, new_leader);
     assert!(new_term > old_term);
 
     ctl.close_all().await;
-    // Wait for all connections to finish
-    sleep(Duration::from_millis(500)).await;
 }
 
 #[tokio::test]
@@ -78,21 +69,13 @@ async fn basic_commit() {
     ctl.serve_all().await;
 
     // Wait for establishing agreement on one leader
-    sleep(Duration::from_millis(1000)).await;
-    let leader = ctl.leader().await.unwrap();
+    let leader = ctl.leader().await;
 
+    // Append command to leader
     let data = b"hello, raft!".to_vec();
+    ctl.agree_one(leader, data).await;
 
-    ctl.append_command(leader, data.clone()).await;
-    let recv_data = ctl.read_commit(leader).await.unwrap();
-    assert!(recv_data.as_slice() == data.as_slice());
-
-    // Wait for commit sync to peers
-    sleep(Duration::from_millis(500)).await;
-    for idx in (0..peers).filter(|idx| *idx != (leader as i32)) {
-        let recv_data = ctl.read_commit(idx as usize).await.unwrap();
-        assert!(recv_data.as_slice() == data.as_slice());
-    }
+    ctl.close_all().await;
 }
 
 #[tokio::test]
@@ -102,30 +85,34 @@ async fn command_forward() {
     ctl.serve_all().await;
 
     // Wait for establishing agreement on one leader
-    sleep(Duration::from_millis(1000)).await;
-    let leader = ctl.leader().await.unwrap();
-    let follower = ctl.follower().await.unwrap();
-
-    let data = b"hello, raft!".to_vec();
+    ctl.leader().await;
 
     // Append command to follower
-    ctl.append_command(follower, data.clone()).await;
+    let data = b"hello, raft!".to_vec();
+    let follower = ctl.follower().await.unwrap();
+    ctl.agree_one(follower, data).await;
 
-    // Expect the command to be forwarded to the leader
-    let recv_data = ctl.read_commit(leader).await.unwrap();
-    assert!(recv_data.as_slice() == data.as_slice());
-
-    // Wait for commit sync to peers
-    sleep(Duration::from_millis(500)).await;
-    for idx in (0..peers).filter(|idx| *idx != (leader as i32)) {
-        let recv_data = ctl.read_commit(idx as usize).await.unwrap();
-        assert!(recv_data.as_slice() == data.as_slice());
-    }
+    ctl.close_all().await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct ControllerConfig {
+    election_wait: Duration,
+    election_retry: i32,
+}
+
+impl Default for ControllerConfig {
+    fn default() -> Self {
+        ControllerConfig {
+            election_wait: Duration::from_millis(200),
+            election_retry: 5,
+        }
+    }
+}
+
 struct Controller {
+    cfg: ControllerConfig,
     services: Vec<RaftService>,
     commit_rxs: Vec<mpsc::Receiver<Arc<Vec<u8>>>>,
 }
@@ -145,6 +132,7 @@ impl Controller {
             commit_rxs.push(commit_rx);
         }
         Controller {
+            cfg: ControllerConfig::default(),
             services,
             commit_rxs,
         }
@@ -171,6 +159,8 @@ impl Controller {
         for i in 0..self.services.len() {
             self.close(i).await;
         }
+        // Wait for all connections to finish
+        sleep(Duration::from_millis(500)).await;
     }
 
     async fn setup_timer(&self, idx: usize) {
@@ -204,13 +194,16 @@ impl Controller {
         (followers, candidates, leader_cnt)
     }
 
-    async fn leader(&self) -> Option<usize> {
-        for i in 0..self.services.len() {
-            if self.role(i).await == state::Role::Leader {
-                return Some(i);
+    async fn leader(&self) -> usize {
+        for _ in 0..self.cfg.election_retry {
+            for i in 0..self.services.len() {
+                if self.role(i).await == state::Role::Leader {
+                    return i;
+                }
             }
+            sleep(self.cfg.election_wait).await;
         }
-        None
+        panic!("No leader elected");
     }
 
     async fn follower(&self) -> Option<usize> {
@@ -228,5 +221,21 @@ impl Controller {
 
     async fn read_commit(&mut self, idx: usize) -> Option<Arc<Vec<u8>>> {
         self.commit_rxs[idx].recv().await
+    }
+
+    async fn agree_one(&mut self, srv: usize, cmd: Vec<u8>) {
+        // Send command to specified service
+        self.append_command(srv, cmd.clone()).await;
+
+        // Expect the command to be committed on leader
+        let leader = self.leader().await;
+        let recv_data = self.read_commit(leader).await.unwrap();
+        assert!(recv_data.as_slice() == cmd.as_slice());
+
+        // Expect the command to be committed on all followers
+        for idx in (0..self.services.len()).filter(|idx| *idx != leader) {
+            let recv_data = self.read_commit(idx as usize).await.unwrap();
+            assert!(recv_data.as_slice() == cmd.as_slice());
+        }
     }
 }

--- a/crates/raft/tests/raft_test.rs
+++ b/crates/raft/tests/raft_test.rs
@@ -147,8 +147,8 @@ impl Default for ControllerConfig {
     fn default() -> Self {
         ControllerConfig {
             election_wait: Duration::from_millis(200),
-            election_retry: 5,
-            recv_timeout: Duration::from_millis(500),
+            election_retry: 10,
+            recv_timeout: Duration::from_millis(1000),
             recv_retry: 2,
         }
     }

--- a/crates/raft/tests/raft_test.rs
+++ b/crates/raft/tests/raft_test.rs
@@ -309,7 +309,7 @@ struct PseudoPersister {
 
 #[async_trait]
 impl Persister for PseudoPersister {
-    async fn replay_wal(&mut self) -> Result<Option<(state::Term, Vec<u8>)>> {
+    async fn read_wal(&mut self) -> Result<Option<(state::Term, Vec<u8>)>> {
         let log = Ok(self.logs.get(self.offset).cloned());
         self.offset += 1;
         log

--- a/crates/raft/tests/raft_test.rs
+++ b/crates/raft/tests/raft_test.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use core::panic;
-use log::log_enabled;
 use raft::config::Config;
 use raft::state;
 use raft::Persister;
@@ -307,7 +307,7 @@ struct PseudoPersister {
     offset: usize,
 }
 
-#[tonic::async_trait]
+#[async_trait]
 impl Persister for PseudoPersister {
     async fn replay_wal(&mut self) -> Result<Option<(state::Term, Vec<u8>)>> {
         let log = Ok(self.logs.get(self.offset).cloned());

--- a/run.sh
+++ b/run.sh
@@ -13,12 +13,11 @@ cargo run --bin mkconf -- -p $NODES
 cargo build
 for node in $(seq 1 $NODES); do
     node_name="${NODE_PREFIX}$(($node - 1))"
-    ./target/debug/radis -c ${node_name}.toml > ${LOG_DIR}/${node_name}.log &
+    ./target/debug/radis -c ${node_name}/conf.toml > ${node_name}/radis.log &
 done
 
 function cleanup {
     pkill -9 radis
-    rm -f ${NODE_PREFIX}*.toml
     exit 0
 }
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     pub listen_addr: String,
     pub raft: RaftConfig,
+    pub raft_data: Option<String>,
 }
 
 impl Config {


### PR DESCRIPTION
## Features

- Add trait `raft::Persister` for read/write WAL and snapshot.
- Implement append and replay WAL for raft committed log.
- Add interface for enabling raft persistence `raft::RaftService::setup_persister()`
- New crate `persister` implements `raft::Persister` trait.
  - `persister::FilePersister` use file for persistence.
- Enable persistence for `radis`.

## Tests

- New `raft/persist`
- New `persister/wal_not_exist`
- New `persister/rw_wal`
